### PR TITLE
refactor: break circular imports with shared_types module

### DIFF
--- a/providers/base.py
+++ b/providers/base.py
@@ -3,10 +3,9 @@
 import logging
 import time
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import Any, Callable, Optional
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
+from shared_types import ToolModelCategory
 
 from .shared import ModelCapabilities, ModelResponse, ProviderType
 
@@ -340,7 +339,7 @@ class ModelProvider(ABC):
     # ------------------------------------------------------------------
     # Preference / registry hooks
     # ------------------------------------------------------------------
-    def get_preferred_model(self, category: "ToolModelCategory", allowed_models: list[str]) -> Optional[str]:
+    def get_preferred_model(self, category: ToolModelCategory, allowed_models: list[str]) -> Optional[str]:
         """Get the preferred model from this provider for a given category."""
 
         return None

--- a/providers/gemini.py
+++ b/providers/gemini.py
@@ -2,14 +2,12 @@
 
 import base64
 import logging
-from typing import TYPE_CHECKING, ClassVar, Optional
-
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
+from typing import ClassVar, Optional
 
 from google import genai
 from google.genai import types
 
+from shared_types import ToolModelCategory
 from utils.env import get_env
 from utils.image_utils import validate_image
 
@@ -453,7 +451,7 @@ class GeminiModelProvider(RegistryBackedProviderMixin, ModelProvider):
             logger.error(f"Error processing image {image_path}: {e}")
             return None
 
-    def get_preferred_model(self, category: "ToolModelCategory", allowed_models: list[str]) -> Optional[str]:
+    def get_preferred_model(self, category: ToolModelCategory, allowed_models: list[str]) -> Optional[str]:
         """Get Gemini's preferred model for a given category from allowed models.
 
         Args:
@@ -463,7 +461,6 @@ class GeminiModelProvider(RegistryBackedProviderMixin, ModelProvider):
         Returns:
             Preferred model name or None
         """
-        from tools.models import ToolModelCategory
 
         if not allowed_models:
             return None

--- a/providers/openai.py
+++ b/providers/openai.py
@@ -1,10 +1,9 @@
 """OpenAI model provider implementation."""
 
 import logging
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import ClassVar, Optional
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
+from shared_types import ToolModelCategory
 
 from .openai_compatible import OpenAICompatibleProvider
 from .registries.openai import OpenAIModelRegistry
@@ -90,7 +89,7 @@ class OpenAIModelProvider(RegistryBackedProviderMixin, OpenAICompatibleProvider)
     # Provider preferences
     # ------------------------------------------------------------------
 
-    def get_preferred_model(self, category: "ToolModelCategory", allowed_models: list[str]) -> Optional[str]:
+    def get_preferred_model(self, category: ToolModelCategory, allowed_models: list[str]) -> Optional[str]:
         """Get OpenAI's preferred model for a given category from allowed models.
 
         Args:
@@ -100,7 +99,6 @@ class OpenAIModelProvider(RegistryBackedProviderMixin, OpenAICompatibleProvider)
         Returns:
             Preferred model name or None
         """
-        from tools.models import ToolModelCategory
 
         if not allowed_models:
             return None

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -1,15 +1,13 @@
 """Model provider registry for managing available providers."""
 
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
+from shared_types import ToolModelCategory
 from utils.env import get_env
 
 from .base import ModelProvider
 from .shared import ProviderType
-
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
 
 
 class ModelProviderRegistry:
@@ -386,7 +384,7 @@ class ModelProviderRegistry:
         return allowed_models
 
     @classmethod
-    def get_preferred_fallback_model(cls, tool_category: Optional["ToolModelCategory"] = None) -> str:
+    def get_preferred_fallback_model(cls, tool_category: Optional[ToolModelCategory] = None) -> str:
         """Get the preferred fallback model based on provider priority and tool category.
 
         This method orchestrates model selection by:
@@ -400,8 +398,6 @@ class ModelProviderRegistry:
         Returns:
             Model name string for fallback use
         """
-        from tools.models import ToolModelCategory
-
         effective_category = tool_category or ToolModelCategory.BALANCED
         first_available_model = None
 

--- a/providers/xai.py
+++ b/providers/xai.py
@@ -1,10 +1,9 @@
 """X.AI (GROK) model provider implementation."""
 
 import logging
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import ClassVar, Optional
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
+from shared_types import ToolModelCategory
 
 from .openai_compatible import OpenAICompatibleProvider
 from .registries.xai import XAIModelRegistry
@@ -42,7 +41,7 @@ class XAIModelProvider(RegistryBackedProviderMixin, OpenAICompatibleProvider):
         """Get the provider type."""
         return ProviderType.XAI
 
-    def get_preferred_model(self, category: "ToolModelCategory", allowed_models: list[str]) -> Optional[str]:
+    def get_preferred_model(self, category: ToolModelCategory, allowed_models: list[str]) -> Optional[str]:
         """Get XAI's preferred model for a given category from allowed models.
 
         Args:
@@ -52,7 +51,6 @@ class XAIModelProvider(RegistryBackedProviderMixin, OpenAICompatibleProvider):
         Returns:
             Preferred model name or None
         """
-        from tools.models import ToolModelCategory
 
         if not allowed_models:
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 include = ["tools*", "providers*", "systemprompts*", "utils*", "conf*", "clink*"]
 
 [tool.setuptools]
-py-modules = ["server", "config"]
+py-modules = ["server", "config", "shared_types"]
 
 [tool.setuptools.package-data]
 "*" = [

--- a/shared_types.py
+++ b/shared_types.py
@@ -1,0 +1,18 @@
+"""Shared type definitions used across providers and tools.
+
+This module exists to break circular imports between the ``tools`` and
+``providers`` packages.  Types placed here must have **no** dependencies
+on either package.
+"""
+
+from enum import Enum
+
+__all__ = ["ToolModelCategory"]
+
+
+class ToolModelCategory(Enum):
+    """Categories for tool model selection based on requirements."""
+
+    EXTENDED_REASONING = "extended_reasoning"  # Requires deep thinking capabilities
+    FAST_RESPONSE = "fast_response"  # Speed and cost efficiency preferred
+    BALANCED = "balanced"  # Balance of capability and performance

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -17,14 +17,12 @@ Key features:
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import Field, model_validator
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
-
 from config import TEMPERATURE_ANALYTICAL
+from shared_types import ToolModelCategory
 from systemprompts import ANALYZE_PROMPT
 from tools.shared.base_models import WorkflowRequest
 
@@ -161,10 +159,8 @@ class AnalyzeTool(WorkflowTool):
     def get_default_temperature(self) -> float:
         return TEMPERATURE_ANALYTICAL
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """Analyze workflow requires thorough analysis and reasoning"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):

--- a/tools/apilookup.py
+++ b/tools/apilookup.py
@@ -3,17 +3,14 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pydantic import Field
 
 from config import TEMPERATURE_ANALYTICAL
+from shared_types import ToolModelCategory
 from tools.shared.base_models import ToolRequest
 from tools.simple.base import SimpleTool
-
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
-
 
 LOOKUP_FIELD_DESCRIPTIONS = {
     "prompt": "The API, SDK, library, framework, or technology you need current documentation, version info, breaking changes, or migration guidance for.",
@@ -89,8 +86,6 @@ class LookupTool(SimpleTool):
         return False
 
     def get_model_category(self) -> ToolModelCategory:
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.FAST_RESPONSE
 
     def get_request_model(self):

--- a/tools/challenge.py
+++ b/tools/challenge.py
@@ -8,14 +8,12 @@ avoid reflexive agreement by prompting deeper analysis and genuine evaluation.
 This is a simple, self-contained tool that doesn't require AI model access.
 """
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
 from pydantic import Field
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
-
 from config import TEMPERATURE_ANALYTICAL
+from shared_types import ToolModelCategory
 from tools.shared.base_models import ToolRequest
 from tools.shared.exceptions import ToolExecutionError
 
@@ -65,10 +63,8 @@ class ChallengeTool(SimpleTool):
     def get_default_temperature(self) -> float:
         return TEMPERATURE_ANALYTICAL
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """Challenge doesn't need a model category since it doesn't use AI"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.FAST_RESPONSE  # Default, but not used
 
     def requires_model(self) -> bool:

--- a/tools/chat.py
+++ b/tools/chat.py
@@ -16,9 +16,9 @@ from pydantic import Field
 
 if TYPE_CHECKING:
     from providers.shared import ModelCapabilities
-    from tools.models import ToolModelCategory
 
 from config import TEMPERATURE_BALANCED
+from shared_types import ToolModelCategory
 from systemprompts import CHAT_PROMPT, GENERATE_CODE_PROMPT
 from tools.shared.base_models import COMMON_FIELD_DESCRIPTIONS, ToolRequest
 
@@ -95,10 +95,8 @@ class ChatTool(SimpleTool):
     def get_default_temperature(self) -> float:
         return TEMPERATURE_BALANCED
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """Chat prioritizes fast responses and cost efficiency"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.FAST_RESPONSE
 
     def get_request_model(self):

--- a/tools/clink.py
+++ b/tools/clink.py
@@ -15,7 +15,8 @@ from clink import get_registry
 from clink.agents import AgentOutput, CLIAgentError, create_agent
 from clink.models import ResolvedCLIClient, ResolvedCLIRole
 from config import TEMPERATURE_BALANCED
-from tools.models import ToolModelCategory, ToolOutput
+from shared_types import ToolModelCategory
+from tools.models import ToolOutput
 from tools.shared.base_models import COMMON_FIELD_DESCRIPTIONS
 from tools.shared.exceptions import ToolExecutionError
 from tools.simple.base import SchemaBuilder, SimpleTool

--- a/tools/clink_listmodels.py
+++ b/tools/clink_listmodels.py
@@ -12,7 +12,8 @@ from typing import Any, Optional
 from mcp.types import TextContent
 
 from clink import get_registry
-from tools.models import ToolModelCategory, ToolOutput
+from shared_types import ToolModelCategory
+from tools.models import ToolOutput
 from tools.shared.base_models import ToolRequest
 from tools.shared.base_tool import BaseTool
 

--- a/tools/codereview.py
+++ b/tools/codereview.py
@@ -17,14 +17,12 @@ Key features:
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import Field, model_validator
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
-
 from config import TEMPERATURE_ANALYTICAL
+from shared_types import ToolModelCategory
 from systemprompts import CODEREVIEW_PROMPT
 from tools.shared.base_models import WorkflowRequest
 
@@ -146,10 +144,8 @@ class CodeReviewTool(WorkflowTool):
     def get_default_temperature(self) -> float:
         return TEMPERATURE_ANALYTICAL
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """Code review requires thorough analysis and reasoning"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):

--- a/tools/consensus.py
+++ b/tools/consensus.py
@@ -17,16 +17,13 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any
-
-from pydantic import Field, model_validator
-
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
+from typing import Any
 
 from mcp.types import TextContent
+from pydantic import Field, model_validator
 
 from config import TEMPERATURE_ANALYTICAL
+from shared_types import ToolModelCategory
 from systemprompts import CONSENSUS_PROMPT
 from tools.shared.base_models import ConsolidatedFindings, WorkflowRequest
 from utils.conversation_memory import MAX_CONVERSATION_TURNS, create_thread, get_thread
@@ -180,8 +177,6 @@ of the evidence, even when it strongly points in one direction.""",
 
     def get_model_category(self) -> ToolModelCategory:
         """Consensus workflow requires extended reasoning"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):

--- a/tools/debug.py
+++ b/tools/debug.py
@@ -16,14 +16,12 @@ Key features:
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
 from pydantic import Field
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
-
 from config import TEMPERATURE_ANALYTICAL
+from shared_types import ToolModelCategory
 from systemprompts import DEBUG_ISSUE_PROMPT
 from tools.shared.base_models import WorkflowRequest
 
@@ -130,10 +128,8 @@ class DebugIssueTool(WorkflowTool):
     def get_default_temperature(self) -> float:
         return TEMPERATURE_ANALYTICAL
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """Debug requires deep analysis and reasoning"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):

--- a/tools/docgen.py
+++ b/tools/docgen.py
@@ -19,14 +19,12 @@ Key features:
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
 from pydantic import Field
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
-
 from config import TEMPERATURE_ANALYTICAL
+from shared_types import ToolModelCategory
 from systemprompts import DOCGEN_PROMPT
 from tools.shared.base_models import WorkflowRequest
 
@@ -115,10 +113,8 @@ class DocgenTool(WorkflowTool):
     def get_default_temperature(self) -> float:
         return TEMPERATURE_ANALYTICAL
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """Docgen requires analytical and reasoning capabilities"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.EXTENDED_REASONING
 
     def requires_model(self) -> bool:

--- a/tools/listmodels.py
+++ b/tools/listmodels.py
@@ -13,7 +13,8 @@ from mcp.types import TextContent
 
 from providers.registries.custom import CustomEndpointModelRegistry
 from providers.registries.openrouter import OpenRouterModelRegistry
-from tools.models import ToolModelCategory, ToolOutput
+from shared_types import ToolModelCategory
+from tools.models import ToolOutput
 from tools.shared.base_models import ToolRequest
 from tools.shared.base_tool import BaseTool
 from utils.env import get_env

--- a/tools/models.py
+++ b/tools/models.py
@@ -2,18 +2,11 @@
 Data models for tool responses and interactions
 """
 
-from enum import Enum
 from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field
 
-
-class ToolModelCategory(Enum):
-    """Categories for tool model selection based on requirements."""
-
-    EXTENDED_REASONING = "extended_reasoning"  # Requires deep thinking capabilities
-    FAST_RESPONSE = "fast_response"  # Speed and cost efficiency preferred
-    BALANCED = "balanced"  # Balance of capability and performance
+from shared_types import ToolModelCategory  # noqa: F401 - re-exported for backward compatibility
 
 
 class ContinuationOffer(BaseModel):

--- a/tools/planner.py
+++ b/tools/planner.py
@@ -21,14 +21,12 @@ architectural decisions, and breaking down large problems into manageable steps.
 """
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pydantic import Field, field_validator
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
-
 from config import TEMPERATURE_BALANCED
+from shared_types import ToolModelCategory
 from systemprompts import PLANNER_PROMPT
 from tools.shared.base_models import WorkflowRequest
 
@@ -139,10 +137,8 @@ class PlannerTool(WorkflowTool):
     def get_default_temperature(self) -> float:
         return TEMPERATURE_BALANCED
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """Planner requires deep analysis and reasoning"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.EXTENDED_REASONING
 
     def requires_model(self) -> bool:

--- a/tools/precommit.py
+++ b/tools/precommit.py
@@ -16,14 +16,12 @@ Key features:
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import Field, model_validator
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
-
 from config import TEMPERATURE_ANALYTICAL
+from shared_types import ToolModelCategory
 from systemprompts import PRECOMMIT_PROMPT
 from tools.shared.base_models import WorkflowRequest
 
@@ -147,10 +145,8 @@ class PrecommitTool(WorkflowTool):
     def get_default_temperature(self) -> float:
         return TEMPERATURE_ANALYTICAL
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """Precommit requires thorough analysis and reasoning"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):

--- a/tools/refactor.py
+++ b/tools/refactor.py
@@ -17,14 +17,12 @@ Key features:
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import Field, model_validator
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
-
 from config import TEMPERATURE_ANALYTICAL
+from shared_types import ToolModelCategory
 from systemprompts import REFACTOR_PROMPT
 from tools.shared.base_models import WorkflowRequest
 
@@ -170,10 +168,8 @@ class RefactorTool(WorkflowTool):
     def get_default_temperature(self) -> float:
         return TEMPERATURE_ANALYTICAL
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """Refactor workflow requires thorough analysis and reasoning"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):

--- a/tools/secaudit.py
+++ b/tools/secaudit.py
@@ -18,14 +18,12 @@ Key features:
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import Field, model_validator
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
-
 from config import TEMPERATURE_ANALYTICAL
+from shared_types import ToolModelCategory
 from systemprompts import SECAUDIT_PROMPT
 from tools.shared.base_models import WorkflowRequest
 
@@ -151,10 +149,8 @@ class SecauditTool(WorkflowTool):
         """Return the temperature for security audit analysis"""
         return TEMPERATURE_ANALYTICAL
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """Return the model category for security audit"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self) -> type:

--- a/tools/shared/base_tool.py
+++ b/tools/shared/base_tool.py
@@ -18,10 +18,10 @@ from mcp.types import TextContent
 
 if TYPE_CHECKING:
     from providers.shared import ModelCapabilities
-    from tools.models import ToolModelCategory
 
 from config import MCP_PROMPT_SIZE_LIMIT
 from providers import ModelProvider, ModelProviderRegistry
+from shared_types import ToolModelCategory
 from utils import estimate_tokens
 from utils.conversation_memory import (
     ConversationTurn,
@@ -623,7 +623,7 @@ class BaseTool(ABC):
         """
         return "medium"  # Default to medium thinking for better reasoning
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """
         Return the model category for this tool.
 
@@ -634,8 +634,6 @@ class BaseTool(ABC):
         Returns:
             ToolModelCategory: Category that influences model selection
         """
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.BALANCED
 
     @abstractmethod

--- a/tools/testgen.py
+++ b/tools/testgen.py
@@ -16,14 +16,12 @@ Key features:
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
 from pydantic import Field, model_validator
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
-
 from config import TEMPERATURE_ANALYTICAL
+from shared_types import ToolModelCategory
 from systemprompts import TESTGEN_PROMPT
 from tools.shared.base_models import WorkflowRequest
 
@@ -124,10 +122,8 @@ class TestGenTool(WorkflowTool):
     def get_default_temperature(self) -> float:
         return TEMPERATURE_ANALYTICAL
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """Test generation requires thorough analysis and reasoning"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):

--- a/tools/thinkdeep.py
+++ b/tools/thinkdeep.py
@@ -14,14 +14,12 @@ Key Features:
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
 from pydantic import Field
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
-
 from config import TEMPERATURE_CREATIVE
+from shared_types import ToolModelCategory
 from systemprompts import THINKDEEP_PROMPT
 from tools.shared.base_models import WorkflowRequest
 
@@ -123,10 +121,8 @@ class ThinkDeepTool(WorkflowTool):
         """Return the tool description"""
         return self.description
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """Return the model category for this tool"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):

--- a/tools/tracer.py
+++ b/tools/tracer.py
@@ -20,14 +20,12 @@ structural relationship analysis, architectural understanding, and code comprehe
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import Field, field_validator
 
-if TYPE_CHECKING:
-    from tools.models import ToolModelCategory
-
 from config import TEMPERATURE_ANALYTICAL
+from shared_types import ToolModelCategory
 from systemprompts import TRACER_PROMPT
 from tools.shared.base_models import WorkflowRequest
 
@@ -166,10 +164,8 @@ class TracerTool(WorkflowTool):
     def get_default_temperature(self) -> float:
         return TEMPERATURE_ANALYTICAL
 
-    def get_model_category(self) -> "ToolModelCategory":
+    def get_model_category(self) -> ToolModelCategory:
         """Tracer requires analytical reasoning for code analysis"""
-        from tools.models import ToolModelCategory
-
         return ToolModelCategory.EXTENDED_REASONING
 
     def requires_model(self) -> bool:

--- a/tools/version.py
+++ b/tools/version.py
@@ -24,7 +24,8 @@ except ImportError:
 from mcp.types import TextContent
 
 from config import __author__, __updated__, __version__
-from tools.models import ToolModelCategory, ToolOutput
+from shared_types import ToolModelCategory
+from tools.models import ToolOutput
 from tools.shared.base_models import ToolRequest
 from tools.shared.base_tool import BaseTool
 


### PR DESCRIPTION
## Summary

- Create `shared_types.py` at the project root with `ToolModelCategory` enum, breaking the circular import cycle between `tools/` and `providers/`
- Remove `TYPE_CHECKING` guards, string annotations, and lazy in-method imports from 26 files
- Re-export `ToolModelCategory` from `tools/models.py` for backward compatibility (no test changes needed)
- Add `shared_types` to `py-modules` in `pyproject.toml` for correct packaging

## Details

The `tools/` and `providers/` packages had a circular dependency: `tools/shared/base_tool.py` imports `ModelProvider` from `providers/` at runtime, while `providers/base.py` needs `ToolModelCategory` from `tools/models.py` for method signatures. This was worked around with 21 `if TYPE_CHECKING:` blocks, string annotations (`"ToolModelCategory"`), and lazy imports inside method bodies.

Moving `ToolModelCategory` (a simple `Enum` with no dependencies) to a neutral `shared_types.py` module eliminates the cycle entirely. Both packages now import from this shared module at the top level.

Two `TYPE_CHECKING` blocks remain (`base_tool.py`, `chat.py`) for `ModelCapabilities`, which has provider-specific dependencies — addressing those would require a larger refactor for minimal benefit.

**28 files changed, 88 insertions, 147 deletions.**

Closes #8

## Test plan

- [x] All 967 unit tests pass (Python 3.10, 3.11, 3.12)
- [x] Linting (ruff, black, isort) passes
- [x] CodeQL analysis passes
- [x] Docker build succeeds
- [x] No remaining lazy `ToolModelCategory` imports in non-test files
- [x] No remaining `TYPE_CHECKING` blocks for `ToolModelCategory` in non-test files
- [x] `shared_types.py` included in `pyproject.toml` `py-modules` for packaging

https://claude.ai/code/session_01PbzkppgHRuLrD63c6HFg3t