### PR TITLE
refactor: consolidate workflow request models and field descriptions

### DIFF
--- a/tests/test_schema_snapshots.py
+++ b/tests/test_schema_snapshots.py
@@ -1,0 +1,394 @@
+"""
+Schema snapshot tests for workflow tools.
+
+These tests capture the current MCP input schema for each workflow tool and
+assert that refactoring does not inadvertently change the schema structure,
+property names, required fields, or field types. Description text changes
+are allowed (and expected during consolidation), but structural changes
+are flagged.
+"""
+
+import pytest
+
+
+def _get_tool_instance(tool_name):
+    """Instantiate a workflow tool by name."""
+    tool_map = {
+        "debug": ("tools.debug", "DebugIssueTool"),
+        "codereview": ("tools.codereview", "CodeReviewTool"),
+        "refactor": ("tools.refactor", "RefactorTool"),
+        "precommit": ("tools.precommit", "PrecommitTool"),
+        "analyze": ("tools.analyze", "AnalyzeTool"),
+        "docgen": ("tools.docgen", "DocgenTool"),
+        "planner": ("tools.planner", "PlannerTool"),
+        "secaudit": ("tools.secaudit", "SecauditTool"),
+        "testgen": ("tools.testgen", "TestGenTool"),
+        "tracer": ("tools.tracer", "TracerTool"),
+        "thinkdeep": ("tools.thinkdeep", "ThinkDeepTool"),
+        "consensus": ("tools.consensus", "ConsensusTool"),
+    }
+    module_path, class_name = tool_map[tool_name]
+    import importlib
+
+    mod = importlib.import_module(module_path)
+    cls = getattr(mod, class_name)
+    return cls()
+
+
+# Expected schema structure per tool: required fields and property names.
+# Captured from actual tool output before consolidation refactor.
+EXPECTED_SCHEMAS = {
+    "debug": {
+        "required": ["findings", "model", "next_step_required", "step", "step_number", "total_steps"],
+        "properties": {
+            "confidence",
+            "continuation_id",
+            "files_checked",
+            "findings",
+            "hypothesis",
+            "images",
+            "issues_found",
+            "model",
+            "next_step_required",
+            "relevant_context",
+            "relevant_files",
+            "step",
+            "step_number",
+            "temperature",
+            "thinking_mode",
+            "total_steps",
+            "use_assistant_model",
+        },
+    },
+    "codereview": {
+        "required": ["findings", "model", "next_step_required", "step", "step_number", "total_steps"],
+        "properties": {
+            "confidence",
+            "continuation_id",
+            "files_checked",
+            "findings",
+            "focus_on",
+            "hypothesis",
+            "images",
+            "issues_found",
+            "model",
+            "next_step_required",
+            "relevant_context",
+            "relevant_files",
+            "review_type",
+            "review_validation_type",
+            "severity_filter",
+            "standards",
+            "step",
+            "step_number",
+            "temperature",
+            "thinking_mode",
+            "total_steps",
+            "use_assistant_model",
+        },
+    },
+    "refactor": {
+        "required": ["findings", "model", "next_step_required", "step", "step_number", "total_steps"],
+        "properties": {
+            "confidence",
+            "continuation_id",
+            "files_checked",
+            "findings",
+            "focus_areas",
+            "hypothesis",
+            "images",
+            "issues_found",
+            "model",
+            "next_step_required",
+            "refactor_type",
+            "relevant_context",
+            "relevant_files",
+            "step",
+            "step_number",
+            "style_guide_examples",
+            "temperature",
+            "thinking_mode",
+            "total_steps",
+            "use_assistant_model",
+        },
+    },
+    "precommit": {
+        "required": ["findings", "model", "next_step_required", "step", "step_number", "total_steps"],
+        "properties": {
+            "compare_to",
+            "confidence",
+            "continuation_id",
+            "files_checked",
+            "findings",
+            "focus_on",
+            "hypothesis",
+            "images",
+            "include_staged",
+            "include_unstaged",
+            "issues_found",
+            "model",
+            "next_step_required",
+            "path",
+            "precommit_type",
+            "relevant_context",
+            "relevant_files",
+            "severity_filter",
+            "step",
+            "step_number",
+            "temperature",
+            "thinking_mode",
+            "total_steps",
+            "use_assistant_model",
+        },
+    },
+    "analyze": {
+        "required": ["findings", "model", "next_step_required", "step", "step_number", "total_steps"],
+        "properties": {
+            "analysis_type",
+            "confidence",
+            "continuation_id",
+            "files_checked",
+            "findings",
+            "images",
+            "issues_found",
+            "model",
+            "next_step_required",
+            "output_format",
+            "relevant_context",
+            "relevant_files",
+            "step",
+            "step_number",
+            "temperature",
+            "thinking_mode",
+            "total_steps",
+            "use_assistant_model",
+        },
+    },
+    "docgen": {
+        "required": [
+            "comments_on_complex_logic",
+            "document_complexity",
+            "document_flow",
+            "findings",
+            "next_step_required",
+            "num_files_documented",
+            "step",
+            "step_number",
+            "total_files_to_document",
+            "total_steps",
+            "update_existing",
+        ],
+        "properties": {
+            "comments_on_complex_logic",
+            "continuation_id",
+            "document_complexity",
+            "document_flow",
+            "findings",
+            "issues_found",
+            "next_step_required",
+            "num_files_documented",
+            "relevant_context",
+            "relevant_files",
+            "step",
+            "step_number",
+            "total_files_to_document",
+            "total_steps",
+            "update_existing",
+            "use_assistant_model",
+        },
+    },
+    "planner": {
+        "required": ["model", "next_step_required", "step", "step_number", "total_steps"],
+        "properties": {
+            "branch_from_step",
+            "branch_id",
+            "continuation_id",
+            "is_branch_point",
+            "is_step_revision",
+            "model",
+            "more_steps_needed",
+            "next_step_required",
+            "revises_step_number",
+            "step",
+            "step_number",
+            "total_steps",
+            "use_assistant_model",
+        },
+    },
+    "secaudit": {
+        "required": ["findings", "model", "next_step_required", "step", "step_number", "total_steps"],
+        "properties": {
+            "audit_focus",
+            "compliance_requirements",
+            "confidence",
+            "continuation_id",
+            "files_checked",
+            "findings",
+            "hypothesis",
+            "images",
+            "issues_found",
+            "model",
+            "next_step_required",
+            "relevant_context",
+            "relevant_files",
+            "security_scope",
+            "severity_filter",
+            "step",
+            "step_number",
+            "temperature",
+            "thinking_mode",
+            "threat_level",
+            "total_steps",
+            "use_assistant_model",
+        },
+    },
+    "testgen": {
+        "required": ["findings", "model", "next_step_required", "step", "step_number", "total_steps"],
+        "properties": {
+            "confidence",
+            "continuation_id",
+            "files_checked",
+            "findings",
+            "hypothesis",
+            "images",
+            "issues_found",
+            "model",
+            "next_step_required",
+            "relevant_context",
+            "relevant_files",
+            "step",
+            "step_number",
+            "temperature",
+            "thinking_mode",
+            "total_steps",
+            "use_assistant_model",
+        },
+    },
+    "tracer": {
+        "required": [
+            "findings",
+            "model",
+            "next_step_required",
+            "step",
+            "step_number",
+            "target_description",
+            "total_steps",
+            "trace_mode",
+        ],
+        "properties": {
+            "confidence",
+            "continuation_id",
+            "files_checked",
+            "findings",
+            "images",
+            "model",
+            "next_step_required",
+            "relevant_context",
+            "relevant_files",
+            "step",
+            "step_number",
+            "target_description",
+            "total_steps",
+            "trace_mode",
+            "use_assistant_model",
+        },
+    },
+    "thinkdeep": {
+        "required": ["findings", "model", "next_step_required", "step", "step_number", "total_steps"],
+        "properties": {
+            "confidence",
+            "continuation_id",
+            "files_checked",
+            "findings",
+            "focus_areas",
+            "hypothesis",
+            "images",
+            "issues_found",
+            "model",
+            "next_step_required",
+            "problem_context",
+            "relevant_context",
+            "relevant_files",
+            "step",
+            "step_number",
+            "temperature",
+            "thinking_mode",
+            "total_steps",
+            "use_assistant_model",
+        },
+    },
+    "consensus": {
+        "required": ["findings", "next_step_required", "step", "step_number", "total_steps"],
+        "properties": {
+            "continuation_id",
+            "current_model_index",
+            "findings",
+            "images",
+            "model_responses",
+            "models",
+            "next_step_required",
+            "relevant_files",
+            "step",
+            "step_number",
+            "total_steps",
+            "use_assistant_model",
+        },
+    },
+}
+
+
+@pytest.mark.parametrize("tool_name", list(EXPECTED_SCHEMAS.keys()))
+def test_schema_properties_match(tool_name):
+    """Assert that each tool's schema has the expected property names."""
+    tool = _get_tool_instance(tool_name)
+    schema = tool.get_input_schema()
+    actual_props = set(schema.get("properties", {}).keys())
+    expected_props = EXPECTED_SCHEMAS[tool_name]["properties"]
+    assert actual_props == expected_props, (
+        f"{tool_name} schema properties mismatch.\n"
+        f"  Missing: {expected_props - actual_props}\n"
+        f"  Extra: {actual_props - expected_props}"
+    )
+
+
+@pytest.mark.parametrize("tool_name", list(EXPECTED_SCHEMAS.keys()))
+def test_schema_required_fields_match(tool_name):
+    """Assert that each tool's schema has the expected required fields.
+
+    The 'model' field is conditionally required based on provider configuration,
+    so we exclude it from comparison to avoid environment-dependent failures.
+    """
+    tool = _get_tool_instance(tool_name)
+    schema = tool.get_input_schema()
+    # Exclude 'model' from comparison — it's conditionally required based on env config
+    actual_required = sorted(f for f in schema.get("required", []) if f != "model")
+    expected_required = sorted(f for f in EXPECTED_SCHEMAS[tool_name]["required"] if f != "model")
+    assert actual_required == expected_required, (
+        f"{tool_name} required fields mismatch (excluding 'model').\n"
+        f"  Expected: {expected_required}\n"
+        f"  Actual: {actual_required}"
+    )
+
+
+@pytest.mark.parametrize("tool_name", list(EXPECTED_SCHEMAS.keys()))
+def test_schema_field_types_preserved(tool_name):
+    """Assert that schema field types have not changed."""
+    tool = _get_tool_instance(tool_name)
+    schema = tool.get_input_schema()
+    props = schema.get("properties", {})
+
+    # Check core workflow field types that must not change
+    type_checks = {
+        "step": "string",
+        "step_number": "integer",
+        "total_steps": "integer",
+        "next_step_required": "boolean",
+        "findings": "string",
+    }
+
+    for field_name, expected_type in type_checks.items():
+        if field_name in props:
+            actual_type = props[field_name].get("type")
+            assert (
+                actual_type == expected_type
+            ), f"{tool_name}.{field_name}: expected type '{expected_type}', got '{actual_type}'"

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -19,7 +19,7 @@ Key features:
 import logging
 from typing import Any, Literal, Optional
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
@@ -119,13 +119,10 @@ class AnalyzeWorkflowRequest(WorkflowRequest):
 
     # Keep thinking_mode from original analyze tool; temperature is inherited from WorkflowRequest
 
-    @model_validator(mode="after")
-    def validate_step_one_requirements(self):
-        """Ensure step 1 has required relevant_files."""
-        if self.step_number == 1:
-            if not self.relevant_files:
-                raise ValueError("Step 1 requires 'relevant_files' field to specify files or directories to analyze")
-        return self
+    # Declarative step-1 validation: require relevant_files on step 1
+    _step_one_required_fields = [
+        ("relevant_files", "Step 1 requires 'relevant_files' field to specify files or directories to analyze"),
+    ]
 
 
 class AnalyzeTool(StatefulTool):
@@ -140,7 +137,6 @@ class AnalyzeTool(StatefulTool):
 
     def __init__(self):
         super().__init__()
-        self.initial_request = None
         self.analysis_config = {}
 
     def get_name(self) -> str:
@@ -171,57 +167,13 @@ class AnalyzeTool(StatefulTool):
         """Generate input schema using WorkflowSchemaBuilder with analyze-specific overrides."""
         from .workflow.schema_builders import WorkflowSchemaBuilder
 
-        # Fields to exclude from analyze workflow (inherited from WorkflowRequest but not used)
-        excluded_fields = {"hypothesis", "confidence"}
-
-        # Analyze workflow-specific field overrides
-        analyze_field_overrides = {
-            "step": {
-                "type": "string",
-                "description": ANALYZE_WORKFLOW_FIELD_DESCRIPTIONS["step"],
-            },
-            "step_number": {
-                "type": "integer",
-                "minimum": 1,
-                "description": ANALYZE_WORKFLOW_FIELD_DESCRIPTIONS["step_number"],
-            },
-            "total_steps": {
-                "type": "integer",
-                "minimum": 1,
-                "description": ANALYZE_WORKFLOW_FIELD_DESCRIPTIONS["total_steps"],
-            },
-            "next_step_required": {
-                "type": "boolean",
-                "description": ANALYZE_WORKFLOW_FIELD_DESCRIPTIONS["next_step_required"],
-            },
-            "findings": {
-                "type": "string",
-                "description": ANALYZE_WORKFLOW_FIELD_DESCRIPTIONS["findings"],
-            },
-            "files_checked": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": ANALYZE_WORKFLOW_FIELD_DESCRIPTIONS["files_checked"],
-            },
-            "relevant_files": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": ANALYZE_WORKFLOW_FIELD_DESCRIPTIONS["relevant_files"],
-            },
+        # Analyze-specific fields
+        analyze_fields = {
+            # Re-add confidence (excluded from workflow defaults, but analyze uses it)
             "confidence": {
                 "type": "string",
                 "enum": ["exploring", "low", "medium", "high", "very_high", "almost_certain", "certain"],
                 "description": ANALYZE_WORKFLOW_FIELD_DESCRIPTIONS["confidence"],
-            },
-            "images": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": ANALYZE_WORKFLOW_FIELD_DESCRIPTIONS["images"],
-            },
-            "issues_found": {
-                "type": "array",
-                "items": {"type": "object"},
-                "description": "Issues or concerns identified during analysis, each with severity level (critical, high, medium, low)",
             },
             "analysis_type": {
                 "type": "string",
@@ -237,13 +189,13 @@ class AnalyzeTool(StatefulTool):
             },
         }
 
-        # Use WorkflowSchemaBuilder with analyze-specific tool fields
         return WorkflowSchemaBuilder.build_schema(
-            tool_specific_fields=analyze_field_overrides,
+            tool_specific_fields=analyze_fields,
+            description_overrides=ANALYZE_WORKFLOW_FIELD_DESCRIPTIONS,
             model_field_schema=self.get_model_field_schema(),
             auto_mode=self.is_effective_auto_mode(),
             tool_name=self.get_name(),
-            excluded_workflow_fields=list(excluded_fields),
+            excluded_workflow_fields=["hypothesis", "confidence"],
         )
 
     def get_required_actions(

--- a/tools/codereview.py
+++ b/tools/codereview.py
@@ -19,7 +19,7 @@ Key features:
 import logging
 from typing import Any, Literal, Optional
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
@@ -105,12 +105,10 @@ class CodeReviewRequest(WorkflowRequest):
     temperature: Optional[float] = Field(default=None, exclude=True)
     thinking_mode: Optional[str] = Field(default=None, exclude=True)
 
-    @model_validator(mode="after")
-    def validate_step_one_requirements(self):
-        """Ensure step 1 has required relevant_files field."""
-        if self.step_number == 1 and not self.relevant_files:
-            raise ValueError("Step 1 requires 'relevant_files' field to specify code files or directories to review")
-        return self
+    # Declarative step-1 validation: require relevant_files on step 1
+    _step_one_required_fields = [
+        ("relevant_files", "Step 1 requires 'relevant_files' field to specify code files or directories to review"),
+    ]
 
 
 class CodeReviewTool(StatefulTool):
@@ -125,7 +123,6 @@ class CodeReviewTool(StatefulTool):
 
     def __init__(self):
         super().__init__()
-        self.initial_request = None
         self.review_config = {}
 
     def get_name(self) -> str:
@@ -156,57 +153,14 @@ class CodeReviewTool(StatefulTool):
         """Generate input schema using WorkflowSchemaBuilder with code review-specific overrides."""
         from .workflow.schema_builders import WorkflowSchemaBuilder
 
-        # Code review workflow-specific field overrides
-        codereview_field_overrides = {
-            "step": {
-                "type": "string",
-                "description": CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS["step"],
-            },
-            "step_number": {
-                "type": "integer",
-                "minimum": 1,
-                "description": CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS["step_number"],
-            },
-            "total_steps": {
-                "type": "integer",
-                "minimum": 1,
-                "description": CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS["total_steps"],
-            },
-            "next_step_required": {
-                "type": "boolean",
-                "description": CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS["next_step_required"],
-            },
-            "findings": {
-                "type": "string",
-                "description": CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS["findings"],
-            },
-            "files_checked": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS["files_checked"],
-            },
-            "relevant_files": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS["relevant_files"],
-            },
+        # Code review-specific fields (not part of standard workflow schema)
+        codereview_fields = {
             "review_validation_type": {
                 "type": "string",
                 "enum": ["external", "internal"],
                 "default": "external",
                 "description": CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS.get("review_validation_type", ""),
             },
-            "issues_found": {
-                "type": "array",
-                "items": {"type": "object"},
-                "description": CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS["issues_found"],
-            },
-            "images": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS["images"],
-            },
-            # Code review-specific fields (for step 1)
             "review_type": {
                 "type": "string",
                 "enum": ["full", "security", "performance", "quick"],
@@ -229,9 +183,9 @@ class CodeReviewTool(StatefulTool):
             },
         }
 
-        # Use WorkflowSchemaBuilder with code review-specific tool fields
         return WorkflowSchemaBuilder.build_schema(
-            tool_specific_fields=codereview_field_overrides,
+            tool_specific_fields=codereview_fields,
+            description_overrides=CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS,
             model_field_schema=self.get_model_field_schema(),
             auto_mode=self.is_effective_auto_mode(),
             tool_name=self.get_name(),

--- a/tools/consensus.py
+++ b/tools/consensus.py
@@ -187,73 +187,12 @@ of the evidence, even when it strongly points in one direction.""",
         """Generate input schema for consensus workflow."""
         from .workflow.schema_builders import WorkflowSchemaBuilder
 
-        # Consensus tool-specific field definitions
-        consensus_field_overrides = {
-            # Override standard workflow fields that need consensus-specific descriptions
-            "step": {
-                "type": "string",
-                "description": CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["step"],
-            },
-            "step_number": {
-                "type": "integer",
-                "minimum": 1,
-                "description": CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["step_number"],
-            },
-            "total_steps": {
-                "type": "integer",
-                "minimum": 1,
-                "description": CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["total_steps"],
-            },
-            "next_step_required": {
-                "type": "boolean",
-                "description": CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["next_step_required"],
-            },
-            "findings": {
-                "type": "string",
-                "description": CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["findings"],
-            },
-            "relevant_files": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["relevant_files"],
-            },
-            # consensus-specific fields (not in base workflow)
-            "models": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "model": {"type": "string"},
-                        "stance": {"type": "string", "enum": ["for", "against", "neutral"], "default": "neutral"},
-                        "stance_prompt": {"type": "string"},
-                    },
-                    "required": ["model"],
-                },
-                "description": (
-                    "User-specified roster of models to consult (provide at least two entries). "
-                    + CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["models"]
-                ),
-                "minItems": 2,
-            },
-            "current_model_index": {
-                "type": "integer",
-                "minimum": 0,
-                "description": CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["current_model_index"],
-            },
-            "model_responses": {
-                "type": "array",
-                "items": {"type": "object"},
-                "description": CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["model_responses"],
-            },
-            "images": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["images"],
-            },
-        }
-
-        # Provide guidance on available models similar to single-model tools
-        model_description = (
+        # Build dynamic model guidance description
+        models_base_desc = (
+            "User-specified roster of models to consult (provide at least two entries). "
+            + CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["models"]
+        )
+        model_guidance = (
             "When the user names a model, you MUST use that exact value or report the "
             "provider error—never swap in another option. Use the `listmodels` tool for the full roster."
         )
@@ -267,46 +206,63 @@ of the evidence, even when it strongly points in one direction.""",
                 top_line = f"{label}: {top_line}; +{remainder} more via `listmodels`."
             else:
                 top_line = f"{label}: {top_line}."
-            model_description = f"{model_description} {top_line}"
+            model_guidance = f"{model_guidance} {top_line}"
         else:
-            model_description = (
-                f"{model_description} No models detected—configure provider credentials or use the `listmodels` tool "
+            model_guidance = (
+                f"{model_guidance} No models detected—configure provider credentials or use the `listmodels` tool "
                 "to inspect availability."
             )
 
         restriction_note = self._get_restriction_note()
         if restriction_note and (remainder > 0 or not summaries):
-            model_description = f"{model_description} {restriction_note}."
+            model_guidance = f"{model_guidance} {restriction_note}."
 
-        existing_models_desc = consensus_field_overrides["models"]["description"]
-        consensus_field_overrides["models"]["description"] = f"{existing_models_desc} {model_description}"
-
-        # Define excluded fields for consensus workflow
-        excluded_workflow_fields = [
-            "files_checked",  # Not used in consensus workflow
-            "relevant_context",  # Not used in consensus workflow
-            "issues_found",  # Not used in consensus workflow
-            "hypothesis",  # Not used in consensus workflow
-            "confidence",  # Not used in consensus workflow
-        ]
-
-        excluded_common_fields = [
-            "model",  # Consensus uses 'models' field instead
-            "temperature",  # Not used in consensus workflow
-            "thinking_mode",  # Not used in consensus workflow
-        ]
+        # Consensus-specific fields (not part of standard workflow schema)
+        consensus_fields = {
+            "models": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "model": {"type": "string"},
+                        "stance": {"type": "string", "enum": ["for", "against", "neutral"], "default": "neutral"},
+                        "stance_prompt": {"type": "string"},
+                    },
+                    "required": ["model"],
+                },
+                "description": f"{models_base_desc} {model_guidance}",
+                "minItems": 2,
+            },
+            "current_model_index": {
+                "type": "integer",
+                "minimum": 0,
+                "description": CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["current_model_index"],
+            },
+            "model_responses": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["model_responses"],
+            },
+        }
 
         requires_model = self.requires_model()
         model_field_schema = self.get_model_field_schema() if requires_model else None
         auto_mode = self.is_effective_auto_mode() if requires_model else False
 
         return WorkflowSchemaBuilder.build_schema(
-            tool_specific_fields=consensus_field_overrides,
+            tool_specific_fields=consensus_fields,
+            description_overrides=CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS,
             model_field_schema=model_field_schema,
             auto_mode=auto_mode,
             tool_name=self.get_name(),
-            excluded_workflow_fields=excluded_workflow_fields,
-            excluded_common_fields=excluded_common_fields,
+            excluded_workflow_fields=[
+                "files_checked",
+                "relevant_context",
+                "issues_found",
+                "hypothesis",
+                "confidence",
+            ],
+            excluded_common_fields=["model", "temperature", "thinking_mode"],
             require_model=requires_model,
         )
 

--- a/tools/debug.py
+++ b/tools/debug.py
@@ -137,62 +137,11 @@ class DebugIssueTool(StatefulTool):
         return DebugInvestigationRequest
 
     def get_input_schema(self) -> dict[str, Any]:
-        """Generate input schema using WorkflowSchemaBuilder with debug-specific overrides."""
+        """Generate input schema using WorkflowSchemaBuilder with debug-specific descriptions."""
         from .workflow.schema_builders import WorkflowSchemaBuilder
 
-        # Debug-specific field overrides
-        debug_field_overrides = {
-            "step": {
-                "type": "string",
-                "description": DEBUG_INVESTIGATION_FIELD_DESCRIPTIONS["step"],
-            },
-            "step_number": {
-                "type": "integer",
-                "minimum": 1,
-                "description": DEBUG_INVESTIGATION_FIELD_DESCRIPTIONS["step_number"],
-            },
-            "total_steps": {
-                "type": "integer",
-                "minimum": 1,
-                "description": DEBUG_INVESTIGATION_FIELD_DESCRIPTIONS["total_steps"],
-            },
-            "next_step_required": {
-                "type": "boolean",
-                "description": DEBUG_INVESTIGATION_FIELD_DESCRIPTIONS["next_step_required"],
-            },
-            "findings": {
-                "type": "string",
-                "description": DEBUG_INVESTIGATION_FIELD_DESCRIPTIONS["findings"],
-            },
-            "files_checked": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": DEBUG_INVESTIGATION_FIELD_DESCRIPTIONS["files_checked"],
-            },
-            "relevant_files": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": DEBUG_INVESTIGATION_FIELD_DESCRIPTIONS["relevant_files"],
-            },
-            "confidence": {
-                "type": "string",
-                "enum": ["exploring", "low", "medium", "high", "very_high", "almost_certain", "certain"],
-                "description": DEBUG_INVESTIGATION_FIELD_DESCRIPTIONS["confidence"],
-            },
-            "hypothesis": {
-                "type": "string",
-                "description": DEBUG_INVESTIGATION_FIELD_DESCRIPTIONS["hypothesis"],
-            },
-            "images": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": DEBUG_INVESTIGATION_FIELD_DESCRIPTIONS["images"],
-            },
-        }
-
-        # Use WorkflowSchemaBuilder with debug-specific tool fields
         return WorkflowSchemaBuilder.build_schema(
-            tool_specific_fields=debug_field_overrides,
+            description_overrides=DEBUG_INVESTIGATION_FIELD_DESCRIPTIONS,
             model_field_schema=self.get_model_field_schema(),
             auto_mode=self.is_effective_auto_mode(),
             tool_name=self.get_name(),

--- a/tools/docgen.py
+++ b/tools/docgen.py
@@ -93,10 +93,6 @@ class DocgenTool(StatefulTool):
     - Modern documentation style appropriate for the language/platform
     """
 
-    def __init__(self):
-        super().__init__()
-        self.initial_request = None
-
     def get_name(self) -> str:
         return "docgen"
 
@@ -206,6 +202,7 @@ class DocgenTool(StatefulTool):
 
         return WorkflowSchemaBuilder.build_schema(
             tool_specific_fields=self.get_tool_fields(),
+            description_overrides=DOCGEN_FIELD_DESCRIPTIONS,
             required_fields=self.get_required_fields(),  # Include docgen-specific required fields
             model_field_schema=None,  # Exclude model field - docgen doesn't need external model selection
             auto_mode=False,  # Force non-auto mode to prevent model field addition

--- a/tools/planner.py
+++ b/tools/planner.py
@@ -161,14 +161,8 @@ class PlannerTool(StatefulTool):
         """Generate input schema for planner workflow using override pattern."""
         from .workflow.schema_builders import WorkflowSchemaBuilder
 
-        # Planner tool-specific field definitions
-        planner_field_overrides = {
-            # Override standard workflow fields that need planning-specific descriptions
-            "step": {
-                "type": "string",
-                "description": PLANNER_FIELD_DESCRIPTIONS["step"],  # Very planning-specific instructions
-            },
-            # NEW planning-specific fields (not in base workflow)
+        # Planner-specific fields (not in base workflow)
+        planner_fields = {
             "is_step_revision": {
                 "type": "boolean",
                 "description": PLANNER_FIELD_DESCRIPTIONS["is_step_revision"],
@@ -197,33 +191,22 @@ class PlannerTool(StatefulTool):
             },
         }
 
-        # Define excluded fields for planner workflow
-        excluded_workflow_fields = [
-            "findings",  # Planning uses step content instead
-            "files_checked",  # Planning doesn't examine files
-            "relevant_files",  # Planning doesn't use files
-            "relevant_context",  # Planning doesn't track code context
-            "issues_found",  # Planning doesn't find issues
-            "confidence",  # Planning uses different confidence model
-            "hypothesis",  # Planning doesn't use hypothesis
-        ]
-
-        excluded_common_fields = [
-            "temperature",  # Planning doesn't need temperature control
-            "thinking_mode",  # Planning doesn't need thinking mode
-            "images",  # Planning doesn't use images
-            "absolute_file_paths",  # Planning doesn't use file attachments
-        ]
-
-        # Build schema with proper field exclusion (following consensus pattern)
         return WorkflowSchemaBuilder.build_schema(
-            tool_specific_fields=planner_field_overrides,
-            required_fields=[],  # No additional required fields beyond workflow defaults
+            tool_specific_fields=planner_fields,
+            description_overrides=PLANNER_FIELD_DESCRIPTIONS,
             model_field_schema=self.get_model_field_schema(),
             auto_mode=self.is_effective_auto_mode(),
             tool_name=self.get_name(),
-            excluded_workflow_fields=excluded_workflow_fields,
-            excluded_common_fields=excluded_common_fields,
+            excluded_workflow_fields=[
+                "findings",
+                "files_checked",
+                "relevant_files",
+                "relevant_context",
+                "issues_found",
+                "confidence",
+                "hypothesis",
+            ],
+            excluded_common_fields=["temperature", "thinking_mode", "images", "absolute_file_paths"],
         )
 
     # ================================================================================

--- a/tools/precommit.py
+++ b/tools/precommit.py
@@ -18,7 +18,7 @@ Key features:
 import logging
 from typing import Any, Literal, Optional
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
@@ -106,12 +106,10 @@ class PrecommitRequest(WorkflowRequest):
     temperature: Optional[float] = Field(default=None, exclude=True)
     thinking_mode: Optional[str] = Field(default=None, exclude=True)
 
-    @model_validator(mode="after")
-    def validate_step_one_requirements(self):
-        """Ensure step 1 has required path field."""
-        if self.step_number == 1 and not self.path:
-            raise ValueError("Step 1 requires 'path' field to specify git repository location")
-        return self
+    # Declarative step-1 validation: require path on step 1
+    _step_one_required_fields = [
+        ("path", "Step 1 requires 'path' field to specify git repository location"),
+    ]
 
 
 class PrecommitTool(StatefulTool):
@@ -126,7 +124,6 @@ class PrecommitTool(StatefulTool):
 
     def __init__(self):
         super().__init__()
-        self.initial_request = None
         self.git_config = {}
 
     def get_name(self) -> str:
@@ -157,39 +154,13 @@ class PrecommitTool(StatefulTool):
         """Generate input schema using WorkflowSchemaBuilder with precommit-specific overrides."""
         from .workflow.schema_builders import WorkflowSchemaBuilder
 
-        # Precommit workflow-specific field overrides
-        precommit_field_overrides = {
-            "step": {
-                "type": "string",
-                "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["step"],
-            },
-            "step_number": {
-                "type": "integer",
-                "minimum": 1,
-                "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["step_number"],
-            },
+        # Precommit-specific fields and fields with custom constraints
+        precommit_fields = {
+            # total_steps has a higher minimum for precommit workflow
             "total_steps": {
                 "type": "integer",
                 "minimum": 3,
                 "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["total_steps"],
-            },
-            "next_step_required": {
-                "type": "boolean",
-                "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["next_step_required"],
-            },
-            "findings": {
-                "type": "string",
-                "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["findings"],
-            },
-            "files_checked": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["files_checked"],
-            },
-            "relevant_files": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["relevant_files"],
             },
             "precommit_type": {
                 "type": "string",
@@ -197,17 +168,6 @@ class PrecommitTool(StatefulTool):
                 "default": "external",
                 "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["precommit_type"],
             },
-            "issues_found": {
-                "type": "array",
-                "items": {"type": "object"},
-                "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["issues_found"],
-            },
-            "images": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["images"],
-            },
-            # Precommit-specific fields (for step 1)
             "path": {
                 "type": "string",
                 "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["path"],
@@ -238,9 +198,9 @@ class PrecommitTool(StatefulTool):
             },
         }
 
-        # Use WorkflowSchemaBuilder with precommit-specific tool fields
         return WorkflowSchemaBuilder.build_schema(
-            tool_specific_fields=precommit_field_overrides,
+            tool_specific_fields=precommit_fields,
+            description_overrides=PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS,
             model_field_schema=self.get_model_field_schema(),
             auto_mode=self.is_effective_auto_mode(),
             tool_name=self.get_name(),

--- a/tools/refactor.py
+++ b/tools/refactor.py
@@ -19,7 +19,7 @@ Key features:
 import logging
 from typing import Any, Literal, Optional
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
@@ -126,14 +126,13 @@ class RefactorRequest(WorkflowRequest):
     temperature: Optional[float] = Field(default=None, exclude=True)
     thinking_mode: Optional[str] = Field(default=None, exclude=True)
 
-    @model_validator(mode="after")
-    def validate_step_one_requirements(self):
-        """Ensure step 1 has required relevant_files field."""
-        if self.step_number == 1 and not self.relevant_files:
-            raise ValueError(
-                "Step 1 requires 'relevant_files' field to specify code files or directories to analyze for refactoring"
-            )
-        return self
+    # Declarative step-1 validation: require relevant_files on step 1
+    _step_one_required_fields = [
+        (
+            "relevant_files",
+            "Step 1 requires 'relevant_files' field to specify code files or directories to analyze for refactoring",
+        ),
+    ]
 
 
 class RefactorTool(StatefulTool):
@@ -149,7 +148,6 @@ class RefactorTool(StatefulTool):
 
     def __init__(self):
         super().__init__()
-        self.initial_request = None
         self.refactor_config = {}
 
     def get_name(self) -> str:
@@ -180,58 +178,15 @@ class RefactorTool(StatefulTool):
         """Generate input schema using WorkflowSchemaBuilder with refactor-specific overrides."""
         from .workflow.schema_builders import WorkflowSchemaBuilder
 
-        # Refactor workflow-specific field overrides
-        refactor_field_overrides = {
-            "step": {
-                "type": "string",
-                "description": REFACTOR_FIELD_DESCRIPTIONS["step"],
-            },
-            "step_number": {
-                "type": "integer",
-                "minimum": 1,
-                "description": REFACTOR_FIELD_DESCRIPTIONS["step_number"],
-            },
-            "total_steps": {
-                "type": "integer",
-                "minimum": 1,
-                "description": REFACTOR_FIELD_DESCRIPTIONS["total_steps"],
-            },
-            "next_step_required": {
-                "type": "boolean",
-                "description": REFACTOR_FIELD_DESCRIPTIONS["next_step_required"],
-            },
-            "findings": {
-                "type": "string",
-                "description": REFACTOR_FIELD_DESCRIPTIONS["findings"],
-            },
-            "files_checked": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": REFACTOR_FIELD_DESCRIPTIONS["files_checked"],
-            },
-            "relevant_files": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": REFACTOR_FIELD_DESCRIPTIONS["relevant_files"],
-            },
+        # Refactor-specific fields and fields with custom types
+        refactor_fields = {
+            # confidence uses a custom enum for refactoring workflow
             "confidence": {
                 "type": "string",
                 "enum": ["exploring", "incomplete", "partial", "complete"],
                 "default": "incomplete",
                 "description": REFACTOR_FIELD_DESCRIPTIONS["confidence"],
             },
-            "issues_found": {
-                "type": "array",
-                "items": {"type": "object"},
-                "description": REFACTOR_FIELD_DESCRIPTIONS["issues_found"],
-            },
-            "images": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": REFACTOR_FIELD_DESCRIPTIONS["images"],
-            },
-            # Refactor-specific fields (for step 1)
-            # Note: Use relevant_files field instead of files for consistency
             "refactor_type": {
                 "type": "string",
                 "enum": ["codesmells", "decompose", "modernize", "organization"],
@@ -250,9 +205,9 @@ class RefactorTool(StatefulTool):
             },
         }
 
-        # Use WorkflowSchemaBuilder with refactor-specific tool fields
         return WorkflowSchemaBuilder.build_schema(
-            tool_specific_fields=refactor_field_overrides,
+            tool_specific_fields=refactor_fields,
+            description_overrides=REFACTOR_FIELD_DESCRIPTIONS,
             model_field_schema=self.get_model_field_schema(),
             auto_mode=self.is_effective_auto_mode(),
             tool_name=self.get_name(),

--- a/tools/secaudit.py
+++ b/tools/secaudit.py
@@ -126,7 +126,6 @@ class SecauditTool(StatefulTool):
 
     def __init__(self):
         super().__init__()
-        self.initial_request = None
         self.security_config = {}
 
     def get_name(self) -> str:
@@ -349,56 +348,8 @@ class SecauditTool(StatefulTool):
         """Generate input schema using WorkflowSchemaBuilder with security audit-specific overrides."""
         from .workflow.schema_builders import WorkflowSchemaBuilder
 
-        # Security audit workflow-specific field overrides
-        secaudit_field_overrides = {
-            "step": {
-                "type": "string",
-                "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["step"],
-            },
-            "step_number": {
-                "type": "integer",
-                "minimum": 1,
-                "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["step_number"],
-            },
-            "total_steps": {
-                "type": "integer",
-                "minimum": 1,
-                "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["total_steps"],
-            },
-            "next_step_required": {
-                "type": "boolean",
-                "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["next_step_required"],
-            },
-            "findings": {
-                "type": "string",
-                "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["findings"],
-            },
-            "files_checked": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["files_checked"],
-            },
-            "relevant_files": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["relevant_files"],
-            },
-            "confidence": {
-                "type": "string",
-                "enum": ["exploring", "low", "medium", "high", "very_high", "almost_certain", "certain"],
-                "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["confidence"],
-            },
-            "issues_found": {
-                "type": "array",
-                "items": {"type": "object"},
-                "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["issues_found"],
-            },
-            "images": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["images"],
-            },
-            # Security audit-specific fields (for step 1)
+        # Security audit-specific fields
+        secaudit_fields = {
             "security_scope": {
                 "type": "string",
                 "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["security_scope"],
@@ -428,9 +379,9 @@ class SecauditTool(StatefulTool):
             },
         }
 
-        # Use WorkflowSchemaBuilder with security audit-specific tool fields
         return WorkflowSchemaBuilder.build_schema(
-            tool_specific_fields=secaudit_field_overrides,
+            tool_specific_fields=secaudit_fields,
+            description_overrides=SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS,
             model_field_schema=self.get_model_field_schema(),
             auto_mode=self.is_effective_auto_mode(),
             tool_name=self.get_name(),

--- a/tools/shared/base_models.py
+++ b/tools/shared/base_models.py
@@ -11,9 +11,9 @@ Key Models:
 """
 
 import logging
-from typing import Optional
+from typing import ClassVar, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -97,19 +97,20 @@ class WorkflowRequest(BaseWorkflowRequest):
     """
     Extended request model for workflow-based tools.
 
-    This model extends ToolRequest with fields specific to the workflow
-    pattern, where tools perform multi-step work with forced pauses between steps.
+    This model extends BaseWorkflowRequest with work-tracking fields specific to
+    the workflow pattern, where tools perform multi-step work with forced pauses.
 
-    Used by: debug, precommit, codereview, refactor, thinkdeep, analyze
+    Used by: debug, precommit, codereview, refactor, thinkdeep, analyze, etc.
+
+    Subclasses can set ``_step_one_required_fields`` to declaratively validate
+    that certain fields are non-empty on step 1, avoiding repetitive validators.
     """
 
-    # Required workflow fields
-    step: str = Field(..., description=WORKFLOW_FIELD_DESCRIPTIONS["step"])
-    step_number: int = Field(..., ge=1, description=WORKFLOW_FIELD_DESCRIPTIONS["step_number"])
-    total_steps: int = Field(..., ge=1, description=WORKFLOW_FIELD_DESCRIPTIONS["total_steps"])
-    next_step_required: bool = Field(..., description=WORKFLOW_FIELD_DESCRIPTIONS["next_step_required"])
+    # Declarative step-1 validation: list of (field_name, error_message) tuples.
+    # Subclasses override this to require specific fields on step 1.
+    _step_one_required_fields: ClassVar[list[tuple[str, str]]] = []
 
-    # Work tracking fields
+    # Work tracking fields (step/step_number/total_steps/next_step_required inherited from BaseWorkflowRequest)
     findings: str = Field(..., description=WORKFLOW_FIELD_DESCRIPTIONS["findings"])
     files_checked: list[str] = Field(default_factory=list, description=WORKFLOW_FIELD_DESCRIPTIONS["files_checked"])
     relevant_files: list[str] = Field(default_factory=list, description=WORKFLOW_FIELD_DESCRIPTIONS["relevant_files"])
@@ -131,6 +132,15 @@ class WorkflowRequest(BaseWorkflowRequest):
             logger.warning(f"Field received string '{v}' instead of list, converting to empty list")
             return []
         return v
+
+    @model_validator(mode="after")
+    def _validate_step_one_requirements(self):
+        """Validate required fields on step 1 using declarative _step_one_required_fields."""
+        if self.step_number == 1 and self._step_one_required_fields:
+            for field_name, error_msg in self._step_one_required_fields:
+                if not getattr(self, field_name, None):
+                    raise ValueError(error_msg)
+        return self
 
 
 class ConsolidatedFindings(BaseModel):

--- a/tools/testgen.py
+++ b/tools/testgen.py
@@ -18,7 +18,7 @@ Key features:
 import logging
 from typing import Any, Optional
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
@@ -82,12 +82,10 @@ class TestGenRequest(WorkflowRequest):
     temperature: Optional[float] = Field(default=None, exclude=True)
     thinking_mode: Optional[str] = Field(default=None, exclude=True)
 
-    @model_validator(mode="after")
-    def validate_step_one_requirements(self):
-        """Ensure step 1 has required relevant_files field."""
-        if self.step_number == 1 and not self.relevant_files:
-            raise ValueError("Step 1 requires 'relevant_files' field to specify code files to generate tests for")
-        return self
+    # Declarative step-1 validation: require relevant_files on step 1
+    _step_one_required_fields = [
+        ("relevant_files", "Step 1 requires 'relevant_files' field to specify code files to generate tests for"),
+    ]
 
 
 class TestGenTool(StatefulTool):
@@ -101,10 +99,6 @@ class TestGenTool(StatefulTool):
     """
 
     __test__ = False  # Prevent pytest from collecting this class as a test
-
-    def __init__(self):
-        super().__init__()
-        self.initial_request = None
 
     def get_name(self) -> str:
         return "testgen"
@@ -131,58 +125,11 @@ class TestGenTool(StatefulTool):
         return TestGenRequest
 
     def get_input_schema(self) -> dict[str, Any]:
-        """Generate input schema using WorkflowSchemaBuilder with test generation-specific overrides."""
+        """Generate input schema using WorkflowSchemaBuilder with test generation-specific descriptions."""
         from .workflow.schema_builders import WorkflowSchemaBuilder
 
-        # Test generation workflow-specific field overrides
-        testgen_field_overrides = {
-            "step": {
-                "type": "string",
-                "description": TESTGEN_WORKFLOW_FIELD_DESCRIPTIONS["step"],
-            },
-            "step_number": {
-                "type": "integer",
-                "minimum": 1,
-                "description": TESTGEN_WORKFLOW_FIELD_DESCRIPTIONS["step_number"],
-            },
-            "total_steps": {
-                "type": "integer",
-                "minimum": 1,
-                "description": TESTGEN_WORKFLOW_FIELD_DESCRIPTIONS["total_steps"],
-            },
-            "next_step_required": {
-                "type": "boolean",
-                "description": TESTGEN_WORKFLOW_FIELD_DESCRIPTIONS["next_step_required"],
-            },
-            "findings": {
-                "type": "string",
-                "description": TESTGEN_WORKFLOW_FIELD_DESCRIPTIONS["findings"],
-            },
-            "files_checked": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": TESTGEN_WORKFLOW_FIELD_DESCRIPTIONS["files_checked"],
-            },
-            "relevant_files": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": TESTGEN_WORKFLOW_FIELD_DESCRIPTIONS["relevant_files"],
-            },
-            "confidence": {
-                "type": "string",
-                "enum": ["exploring", "low", "medium", "high", "very_high", "almost_certain", "certain"],
-                "description": TESTGEN_WORKFLOW_FIELD_DESCRIPTIONS["confidence"],
-            },
-            "images": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": TESTGEN_WORKFLOW_FIELD_DESCRIPTIONS["images"],
-            },
-        }
-
-        # Use WorkflowSchemaBuilder with test generation-specific tool fields
         return WorkflowSchemaBuilder.build_schema(
-            tool_specific_fields=testgen_field_overrides,
+            description_overrides=TESTGEN_WORKFLOW_FIELD_DESCRIPTIONS,
             model_field_schema=self.get_model_field_schema(),
             auto_mode=self.is_effective_auto_mode(),
             tool_name=self.get_name(),

--- a/tools/tracer.py
+++ b/tools/tracer.py
@@ -145,7 +145,6 @@ class TracerTool(StatefulTool):
 
     def __init__(self):
         super().__init__()
-        self.initial_request = None
         self.trace_config = {}
 
     def get_name(self) -> str:
@@ -223,6 +222,7 @@ class TracerTool(StatefulTool):
 
         return WorkflowSchemaBuilder.build_schema(
             tool_specific_fields=self.get_tool_fields(),
+            description_overrides=TRACER_WORKFLOW_FIELD_DESCRIPTIONS,
             required_fields=["target_description", "trace_mode"],  # Step 1 requires these
             model_field_schema=self.get_model_field_schema(),
             auto_mode=self.is_effective_auto_mode(),

--- a/tools/workflow/schema_builders.py
+++ b/tools/workflow/schema_builders.py
@@ -89,18 +89,24 @@ class WorkflowSchemaBuilder:
         excluded_workflow_fields: list[str] = None,
         excluded_common_fields: list[str] = None,
         require_model: bool = False,
+        description_overrides: dict[str, str] = None,
     ) -> dict[str, Any]:
         """
         Build complete schema for workflow tools.
 
         Args:
-            tool_specific_fields: Additional fields specific to the tool
+            tool_specific_fields: Additional fields specific to the tool, or full
+                schema overrides for standard fields (replaces the entire field schema)
             required_fields: List of required field names (beyond workflow defaults)
             model_field_schema: Schema for the model field
             auto_mode: Whether the tool is in auto mode (affects model requirement)
             tool_name: Name of the tool (for schema title)
             excluded_workflow_fields: Workflow fields to exclude from schema (e.g., for planning tools)
             excluded_common_fields: Common fields to exclude from schema
+            description_overrides: Dict mapping field names to custom description strings.
+                This allows tools to customize descriptions for standard workflow/common
+                fields without re-declaring the entire field schema. Applied after
+                workflow and common fields are added but before tool_specific_fields.
 
         Returns:
             Complete JSON schema for the workflow tool
@@ -120,6 +126,13 @@ class WorkflowSchemaBuilder:
             for field in excluded_common_fields:
                 common_fields.pop(field, None)
         properties.update(common_fields)
+
+        # Apply description overrides to existing fields (workflow + common)
+        if description_overrides:
+            for field_name, description in description_overrides.items():
+                if field_name in properties:
+                    # Deep copy the field schema and update just the description
+                    properties[field_name] = {**properties[field_name], "description": description}
 
         # Add model field if provided
         if model_field_schema:


### PR DESCRIPTION
## Summary

Resolves #5 — reduces ~373 lines of duplication across 12 workflow tools by consolidating shared workflow request models and field descriptions.

- **`description_overrides` in `WorkflowSchemaBuilder.build_schema()`**: Tools can now customize field descriptions without re-declaring full field schemas. The override shallow-copies the field dict and replaces only the `description` key, preserving all constraints (`minimum`, `enum`, `type`, etc.).
- **Declarative `_step_one_required_fields` ClassVar**: Replaces per-tool `model_validator` boilerplate with a simple class-level list of `(field_name, error_message)` tuples validated by a single base-class validator.
- **Removed redundant `self.initial_request = None`**: Already handled by `StatefulTool.__init__()`.
- **Removed duplicate field declarations**: `step`, `step_number`, `total_steps`, `next_step_required` were declared in both `BaseWorkflowRequest` and `WorkflowRequest`.
- **36 new schema snapshot tests**: Parametrized across all 12 tools to prevent structural regressions in property names, required fields, and field types.

## Changes

- 13 source files modified, 1 test file created
- 523 deletions, 150 insertions (net -373 lines)
- All 1034 existing tests + 36 new snapshot tests pass
- ruff, black, isort all clean

## Design decisions

- **No `build_workflow_descriptions()` factory**: Per-tool descriptions contain tool-specific behavioral instructions (prompt engineering), not mechanical variations — a template factory would be the wrong abstraction.
- **No `tool_config` rename**: 27 references across 6 files with low semantic benefit doesn't justify the churn.
- **Special-case handling preserved**: Refactor's custom confidence enum, precommit's `minimum: 3` for `total_steps`, and consensus's custom validator all work correctly alongside the new base-class mechanisms.

## Test plan

- [x] All 1034 existing unit tests pass
- [x] 36 new schema snapshot tests pass (properties, required fields, field types)
- [x] `description_overrides` preserves field constraints (verified: `minimum`, `enum`)
- [x] `_step_one_required_fields` validator fires correctly on step 1, is no-op on step 2+
- [x] Consensus dual-validator (custom + inherited) works without conflict
- [x] ruff, black, isort all pass

https://claude.ai/code/session_01S9wa7mNidnZPVu176zz3rU