### PR TITLE
refactor: eliminate per-tool boilerplate methods

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,26 +42,11 @@ IS_AUTO_MODE = DEFAULT_MODEL.lower() == "auto"
 # - Clean separation of concerns (providers own their model definitions)
 
 
-# Temperature defaults for different tool types
+# Default temperature for all tools.
 # NOTE: Gemini 3.0 Pro notes suggest temperature should be set at 1.0
 # in most cases. Lowering it can affect the models 'reasoning' abilities.
 # Newer models / inference stacks are able to handle their randomness better.
-
-# Temperature controls the randomness/creativity of model responses
-# Lower values (0.0-0.3) produce more deterministic, focused responses
-# Higher values (0.7-1.0) produce more creative, varied responses
-
-# TEMPERATURE_ANALYTICAL: Used for tasks requiring precision and consistency
-# Ideal for code review, debugging, and error analysis where accuracy is critical
-TEMPERATURE_ANALYTICAL = 1.0  # For code review, debugging
-
-# TEMPERATURE_BALANCED: Middle ground for general conversations
-# Provides a good balance between consistency and helpful variety
-TEMPERATURE_BALANCED = 1.0  # For general chat
-
-# TEMPERATURE_CREATIVE: Higher temperature for exploratory tasks
-# Used when brainstorming, exploring alternatives, or architectural discussions
-TEMPERATURE_CREATIVE = 1.0  # For architecture, deep thinking
+DEFAULT_TEMPERATURE = 1.0
 
 # Thinking Mode Defaults
 # DEFAULT_THINKING_MODE_THINKDEEP: Default thinking depth for extended reasoning tool

--- a/docs/adding_tools.md
+++ b/docs/adding_tools.md
@@ -34,7 +34,10 @@ Regardless of architecture, subclasses of `BaseTool` must provide:
 
 The base class already handles model selection (`ToolModelCategory`), conversation memory, token budgeting, safety
 failures, retries, and serialization. Set the `MODEL_CATEGORY` class attribute to change model selection behaviour,
-and override hooks like `format_response` only when you need behaviour different from the defaults.
+and override hooks like `format_response` only when you need behaviour different from the defaults; in rare cases
+where a tool truly requires different sampling or reasoning behaviour, you can also override advanced hooks such
+as `get_default_temperature` or `get_default_thinking_mode`, but this should generally be avoided so tools remain
+consistent with the shared infrastructure.
 
 ## 3. Implementing a Simple Tool
 

--- a/docs/adding_tools.md
+++ b/docs/adding_tools.md
@@ -33,8 +33,8 @@ Regardless of architecture, subclasses of `BaseTool` must provide:
   `prepare_chat_style_prompt` or `build_standard_prompt`.
 
 The base class already handles model selection (`ToolModelCategory`), conversation memory, token budgeting, safety
-failures, retries, and serialization. Override hooks like `get_default_temperature`, `get_model_category`, or
-`format_response` only when you need behaviour different from the defaults.
+failures, retries, and serialization. Set the `MODEL_CATEGORY` class attribute to change model selection behaviour,
+and override hooks like `format_response` only when you need behaviour different from the defaults.
 
 ## 3. Implementing a Simple Tool
 

--- a/tests/test_challenge.py
+++ b/tests/test_challenge.py
@@ -28,7 +28,7 @@ class TestChallengeTool:
         assert "reflexive agreement" in self.tool.get_description()
         assert "critical thinking" in self.tool.get_description()
         assert "reasoned analysis" in self.tool.get_description()
-        assert self.tool.get_default_temperature() == 1.0  # TEMPERATURE_ANALYTICAL
+        assert self.tool.get_default_temperature() == 1.0  # DEFAULT_TEMPERATURE
 
     def test_requires_model(self):
         """Test that challenge tool doesn't require a model"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,9 +4,7 @@ Tests for configuration
 
 from config import (
     DEFAULT_MODEL,
-    TEMPERATURE_ANALYTICAL,
-    TEMPERATURE_BALANCED,
-    TEMPERATURE_CREATIVE,
+    DEFAULT_TEMPERATURE,
     __author__,
     __updated__,
     __version__,
@@ -34,7 +32,5 @@ class TestConfig:
         assert DEFAULT_MODEL == "gemini-3-flash-preview"
 
     def test_temperature_defaults(self):
-        """Test temperature constants"""
-        assert TEMPERATURE_ANALYTICAL == 1.0
-        assert TEMPERATURE_BALANCED == 1.0
-        assert TEMPERATURE_CREATIVE == 1.0
+        """Test temperature constant"""
+        assert DEFAULT_TEMPERATURE == 1.0

--- a/tests/test_consensus.py
+++ b/tests/test_consensus.py
@@ -19,7 +19,7 @@ class TestConsensusTool:
 
         assert tool.get_name() == "consensus"
         assert "consensus" in tool.get_description()
-        assert tool.get_default_temperature() == 1.0  # TEMPERATURE_ANALYTICAL
+        assert tool.get_default_temperature() == 1.0  # DEFAULT_TEMPERATURE
         assert tool.get_model_category() == ToolModelCategory.EXTENDED_REASONING
         assert tool.requires_model() is False  # Consensus manages its own models
 

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -15,7 +15,7 @@ class TestDebugTool:
 
         assert tool.get_name() == "debug"
         assert "debugging and root cause analysis" in tool.get_description()
-        assert tool.get_default_temperature() == 1.0  # TEMPERATURE_ANALYTICAL
+        assert tool.get_default_temperature() == 1.0  # DEFAULT_TEMPERATURE
         assert tool.get_model_category() == ToolModelCategory.EXTENDED_REASONING
         assert tool.requires_model() is True
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -20,7 +20,7 @@ class TestPlannerTool:
 
         assert tool.get_name() == "planner"
         assert "sequential planning" in tool.get_description()
-        assert tool.get_default_temperature() == 1.0  # TEMPERATURE_BALANCED
+        assert tool.get_default_temperature() == 1.0  # DEFAULT_TEMPERATURE
         assert tool.get_model_category() == ToolModelCategory.EXTENDED_REASONING
         assert tool.get_default_thinking_mode() == "medium"
 

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -109,11 +109,11 @@ class TestRefactorTool:
         assert category == ToolModelCategory.EXTENDED_REASONING
 
     def test_default_temperature(self, refactor_tool):
-        """Test that the refactor tool uses analytical temperature"""
-        from config import TEMPERATURE_ANALYTICAL
+        """Test that the refactor tool uses default temperature"""
+        from config import DEFAULT_TEMPERATURE
 
         temp = refactor_tool.get_default_temperature()
-        assert temp == TEMPERATURE_ANALYTICAL
+        assert temp == DEFAULT_TEMPERATURE
 
     # Note: format_response tests removed - workflow tools use different response format
 

--- a/tests/test_secaudit.py
+++ b/tests/test_secaudit.py
@@ -17,7 +17,7 @@ class TestSecauditTool:
 
         assert tool.get_name() == "secaudit"
         assert "security audit" in tool.get_description()
-        assert tool.get_default_temperature() == 1.0  # TEMPERATURE_ANALYTICAL
+        assert tool.get_default_temperature() == 1.0  # DEFAULT_TEMPERATURE
         assert tool.get_model_category() == ToolModelCategory.EXTENDED_REASONING
         assert tool.requires_model() is True
 

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -21,7 +21,6 @@ from typing import Any, Literal, Optional
 
 from pydantic import Field
 
-from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
 from systemprompts import ANALYZE_PROMPT
 from tools.shared.base_models import WorkflowRequest
@@ -152,12 +151,7 @@ class AnalyzeTool(StatefulTool):
     def get_system_prompt(self) -> str:
         return ANALYZE_PROMPT
 
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_ANALYTICAL
-
-    def get_model_category(self) -> ToolModelCategory:
-        """Analyze workflow requires thorough analysis and reasoning"""
-        return ToolModelCategory.EXTENDED_REASONING
+    MODEL_CATEGORY = ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):
         """Return the analyze workflow-specific request model."""

--- a/tools/apilookup.py
+++ b/tools/apilookup.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from pydantic import Field
 
-from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
 from tools.shared.base_models import ToolRequest
 from tools.shared.base_tool import BaseTool
@@ -79,14 +78,10 @@ class LookupTool(BaseTool):
     def get_system_prompt(self) -> str:
         return ""
 
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_ANALYTICAL
+    MODEL_CATEGORY = ToolModelCategory.FAST_RESPONSE
 
     def requires_model(self) -> bool:
         return False
-
-    def get_model_category(self) -> ToolModelCategory:
-        return ToolModelCategory.FAST_RESPONSE
 
     def get_request_model(self):
         return LookupRequest

--- a/tools/challenge.py
+++ b/tools/challenge.py
@@ -12,7 +12,6 @@ from typing import Any, Optional
 
 from pydantic import Field
 
-from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
 from tools.shared.base_models import ToolRequest
 from tools.shared.exceptions import ToolExecutionError
@@ -60,12 +59,7 @@ class ChallengeTool(BaseTool):
         # Challenge tool doesn't need a system prompt since it doesn't call AI
         return ""
 
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_ANALYTICAL
-
-    def get_model_category(self) -> ToolModelCategory:
-        """Challenge doesn't need a model category since it doesn't use AI"""
-        return ToolModelCategory.FAST_RESPONSE  # Default, but not used
+    MODEL_CATEGORY = ToolModelCategory.FAST_RESPONSE
 
     def requires_model(self) -> bool:
         """

--- a/tools/chat.py
+++ b/tools/chat.py
@@ -17,7 +17,6 @@ from pydantic import Field
 if TYPE_CHECKING:
     from providers.shared import ModelCapabilities
 
-from config import TEMPERATURE_BALANCED
 from shared_types import ToolModelCategory
 from systemprompts import CHAT_PROMPT, GENERATE_CODE_PROMPT
 from tools.shared.base_models import COMMON_FIELD_DESCRIPTIONS, ToolRequest
@@ -92,12 +91,7 @@ class ChatTool(BaseTool):
             prompts.append(GENERATE_CODE_PROMPT)
         return prompts
 
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_BALANCED
-
-    def get_model_category(self) -> ToolModelCategory:
-        """Chat prioritizes fast responses and cost efficiency"""
-        return ToolModelCategory.FAST_RESPONSE
+    MODEL_CATEGORY = ToolModelCategory.FAST_RESPONSE
 
     def get_request_model(self):
         """Return the Chat-specific request model"""

--- a/tools/clink.py
+++ b/tools/clink.py
@@ -14,8 +14,6 @@ from pydantic import BaseModel, Field
 from clink import get_registry
 from clink.agents import AgentOutput, CLIAgentError, create_agent
 from clink.models import ResolvedCLIClient, ResolvedCLIRole
-from config import TEMPERATURE_BALANCED
-from shared_types import ToolModelCategory
 from tools.models import ToolOutput
 from tools.shared.base_models import COMMON_FIELD_DESCRIPTIONS
 from tools.shared.base_tool import BaseTool
@@ -104,12 +102,6 @@ class CLinkTool(BaseTool):
 
     def requires_model(self) -> bool:
         return False
-
-    def get_model_category(self) -> ToolModelCategory:
-        return ToolModelCategory.BALANCED
-
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_BALANCED
 
     def get_system_prompt(self) -> str:
         return self._active_system_prompt or ""

--- a/tools/clink_listmodels.py
+++ b/tools/clink_listmodels.py
@@ -194,6 +194,4 @@ class ClinkListModelsTool(BaseTool):
 
         return [TextContent(type="text", text=tool_output.model_dump_json())]
 
-    def get_model_category(self) -> ToolModelCategory:
-        """Return the model category for this tool."""
-        return ToolModelCategory.FAST_RESPONSE  # Simple listing, no AI needed
+    MODEL_CATEGORY = ToolModelCategory.FAST_RESPONSE

--- a/tools/codereview.py
+++ b/tools/codereview.py
@@ -21,7 +21,6 @@ from typing import Any, Literal, Optional
 
 from pydantic import Field
 
-from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
 from systemprompts import CODEREVIEW_PROMPT
 from tools.shared.base_models import WorkflowRequest
@@ -138,12 +137,7 @@ class CodeReviewTool(StatefulTool):
     def get_system_prompt(self) -> str:
         return CODEREVIEW_PROMPT
 
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_ANALYTICAL
-
-    def get_model_category(self) -> ToolModelCategory:
-        """Code review requires thorough analysis and reasoning"""
-        return ToolModelCategory.EXTENDED_REASONING
+    MODEL_CATEGORY = ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):
         """Return the code review workflow-specific request model."""

--- a/tools/consensus.py
+++ b/tools/consensus.py
@@ -22,7 +22,6 @@ from typing import Any
 from mcp.types import TextContent
 from pydantic import Field, model_validator
 
-from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
 from systemprompts import CONSENSUS_PROMPT
 from tools.shared.base_models import ConsolidatedFindings, WorkflowRequest
@@ -172,12 +171,7 @@ Remember: Artificial balance that misrepresents reality is not helpful. True bal
 of the evidence, even when it strongly points in one direction.""",
         )
 
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_ANALYTICAL
-
-    def get_model_category(self) -> ToolModelCategory:
-        """Consensus workflow requires extended reasoning"""
-        return ToolModelCategory.EXTENDED_REASONING
+    MODEL_CATEGORY = ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):
         """Return the consensus workflow-specific request model."""

--- a/tools/debug.py
+++ b/tools/debug.py
@@ -20,7 +20,6 @@ from typing import Any, Optional
 
 from pydantic import Field
 
-from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
 from systemprompts import DEBUG_ISSUE_PROMPT
 from tools.shared.base_models import WorkflowRequest
@@ -125,12 +124,7 @@ class DebugIssueTool(StatefulTool):
     def get_system_prompt(self) -> str:
         return DEBUG_ISSUE_PROMPT
 
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_ANALYTICAL
-
-    def get_model_category(self) -> ToolModelCategory:
-        """Debug requires deep analysis and reasoning"""
-        return ToolModelCategory.EXTENDED_REASONING
+    MODEL_CATEGORY = ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):
         """Return the debug-specific request model."""

--- a/tools/docgen.py
+++ b/tools/docgen.py
@@ -23,7 +23,6 @@ from typing import Any, Optional
 
 from pydantic import Field
 
-from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
 from systemprompts import DOCGEN_PROMPT
 from tools.shared.base_models import WorkflowRequest
@@ -106,12 +105,7 @@ class DocgenTool(StatefulTool):
     def get_system_prompt(self) -> str:
         return DOCGEN_PROMPT
 
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_ANALYTICAL
-
-    def get_model_category(self) -> ToolModelCategory:
-        """Docgen requires analytical and reasoning capabilities"""
-        return ToolModelCategory.EXTENDED_REASONING
+    MODEL_CATEGORY = ToolModelCategory.EXTENDED_REASONING
 
     def requires_model(self) -> bool:
         """

--- a/tools/listmodels.py
+++ b/tools/listmodels.py
@@ -399,6 +399,4 @@ class ListModelsTool(BaseTool):
 
         return [TextContent(type="text", text=tool_output.model_dump_json())]
 
-    def get_model_category(self) -> ToolModelCategory:
-        """Return the model category for this tool."""
-        return ToolModelCategory.FAST_RESPONSE  # Simple listing, no AI needed
+    MODEL_CATEGORY = ToolModelCategory.FAST_RESPONSE

--- a/tools/planner.py
+++ b/tools/planner.py
@@ -25,7 +25,6 @@ from typing import Any
 
 from pydantic import Field, field_validator
 
-from config import TEMPERATURE_BALANCED
 from shared_types import ToolModelCategory
 from systemprompts import PLANNER_PROMPT
 from tools.shared.base_models import WorkflowRequest
@@ -134,12 +133,7 @@ class PlannerTool(StatefulTool):
     def get_system_prompt(self) -> str:
         return PLANNER_PROMPT
 
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_BALANCED
-
-    def get_model_category(self) -> ToolModelCategory:
-        """Planner requires deep analysis and reasoning"""
-        return ToolModelCategory.EXTENDED_REASONING
+    MODEL_CATEGORY = ToolModelCategory.EXTENDED_REASONING
 
     def requires_model(self) -> bool:
         """

--- a/tools/precommit.py
+++ b/tools/precommit.py
@@ -20,7 +20,6 @@ from typing import Any, Literal, Optional
 
 from pydantic import Field
 
-from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
 from systemprompts import PRECOMMIT_PROMPT
 from tools.shared.base_models import WorkflowRequest
@@ -139,12 +138,7 @@ class PrecommitTool(StatefulTool):
     def get_system_prompt(self) -> str:
         return PRECOMMIT_PROMPT
 
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_ANALYTICAL
-
-    def get_model_category(self) -> ToolModelCategory:
-        """Precommit requires thorough analysis and reasoning"""
-        return ToolModelCategory.EXTENDED_REASONING
+    MODEL_CATEGORY = ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):
         """Return the precommit workflow-specific request model."""

--- a/tools/refactor.py
+++ b/tools/refactor.py
@@ -21,7 +21,6 @@ from typing import Any, Literal, Optional
 
 from pydantic import Field
 
-from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
 from systemprompts import REFACTOR_PROMPT
 from tools.shared.base_models import WorkflowRequest
@@ -163,12 +162,7 @@ class RefactorTool(StatefulTool):
     def get_system_prompt(self) -> str:
         return REFACTOR_PROMPT
 
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_ANALYTICAL
-
-    def get_model_category(self) -> ToolModelCategory:
-        """Refactor workflow requires thorough analysis and reasoning"""
-        return ToolModelCategory.EXTENDED_REASONING
+    MODEL_CATEGORY = ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):
         """Return the refactor workflow-specific request model."""

--- a/tools/secaudit.py
+++ b/tools/secaudit.py
@@ -22,7 +22,6 @@ from typing import Any, Literal, Optional
 
 from pydantic import Field, model_validator
 
-from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
 from systemprompts import SECAUDIT_PROMPT
 from tools.shared.base_models import WorkflowRequest
@@ -144,13 +143,7 @@ class SecauditTool(StatefulTool):
         """Return the system prompt for expert security analysis."""
         return SECAUDIT_PROMPT
 
-    def get_default_temperature(self) -> float:
-        """Return the temperature for security audit analysis"""
-        return TEMPERATURE_ANALYTICAL
-
-    def get_model_category(self) -> ToolModelCategory:
-        """Return the model category for security audit"""
-        return ToolModelCategory.EXTENDED_REASONING
+    MODEL_CATEGORY = ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self) -> type:
         """Return the workflow request model class"""

--- a/tools/shared/base_tool.py
+++ b/tools/shared/base_tool.py
@@ -137,7 +137,6 @@ class BaseTool(ABC):
         # Cache tool metadata at initialization to avoid repeated calls
         self.name = self.get_name()
         self.description = self.get_description()
-        self.default_temperature = self.get_default_temperature()
         # Tool initialization complete
 
     @abstractmethod
@@ -551,13 +550,12 @@ class BaseTool(ABC):
         """
         Return the default temperature setting for this tool.
 
-        Override this method to set tool-specific temperature defaults.
-        Lower values (0.0-0.3) for analytical tasks, higher (0.7-1.0) for creative tasks.
-
         Returns:
-            float: Default temperature between 0.0 and 1.0
+            float: Default temperature (1.0)
         """
-        return 0.5
+        from config import DEFAULT_TEMPERATURE
+
+        return DEFAULT_TEMPERATURE
 
     def wants_line_numbers_by_default(self) -> bool:
         """
@@ -583,18 +581,18 @@ class BaseTool(ABC):
         """
         return "medium"  # Default to medium thinking for better reasoning
 
+    MODEL_CATEGORY = ToolModelCategory.BALANCED
+
     def get_model_category(self) -> ToolModelCategory:
         """
         Return the model category for this tool.
 
-        Model category influences which model is selected in auto mode.
-        Override to specify whether your tool needs extended reasoning,
-        fast response, or balanced capabilities.
+        Tools override by setting the MODEL_CATEGORY class attribute.
 
         Returns:
             ToolModelCategory: Category that influences model selection
         """
-        return ToolModelCategory.BALANCED
+        return self.MODEL_CATEGORY
 
     def get_request_model(self):
         """

--- a/tools/shared/base_tool.py
+++ b/tools/shared/base_tool.py
@@ -551,7 +551,7 @@ class BaseTool(ABC):
         Return the default temperature setting for this tool.
 
         Returns:
-            float: Default temperature (1.0)
+            float: Default temperature from config.DEFAULT_TEMPERATURE
         """
         from config import DEFAULT_TEMPERATURE
 

--- a/tools/shared/request_helpers.py
+++ b/tools/shared/request_helpers.py
@@ -9,72 +9,46 @@ from typing import Optional
 
 def get_request_model_name(request) -> Optional[str]:
     """Get model name from request."""
-    try:
-        return request.model
-    except AttributeError:
-        return None
+    return getattr(request, "model", None)
 
 
 def get_request_images(request) -> list:
     """Get images from request."""
-    try:
-        return request.images if request.images is not None else []
-    except AttributeError:
-        return []
+    return getattr(request, "images", None) or []
 
 
 def get_request_continuation_id(request) -> Optional[str]:
     """Get continuation_id from request."""
-    try:
-        return request.continuation_id
-    except AttributeError:
-        return None
+    return getattr(request, "continuation_id", None)
 
 
 def get_request_prompt(request) -> str:
     """Get prompt from request."""
-    try:
-        return request.prompt
-    except AttributeError:
-        return ""
+    return getattr(request, "prompt", "")
 
 
 def get_request_temperature(request) -> Optional[float]:
     """Get temperature from request."""
-    try:
-        return request.temperature
-    except AttributeError:
-        return None
+    return getattr(request, "temperature", None)
 
 
 def get_request_thinking_mode(request) -> Optional[str]:
     """Get thinking_mode from request."""
-    try:
-        return request.thinking_mode
-    except AttributeError:
-        return None
+    return getattr(request, "thinking_mode", None)
 
 
 def get_request_files(request) -> list:
     """Get absolute file paths from request."""
-    try:
-        files = request.absolute_file_paths
-    except AttributeError:
-        files = None
-    if files is None:
-        return []
-    return files
+    return getattr(request, "absolute_file_paths", None) or []
 
 
 def get_request_as_dict(request) -> dict:
     """Convert request to dictionary."""
-    try:
-        return request.model_dump()
-    except AttributeError:
-        try:
-            return request.dict()
-        except AttributeError:
-            return {"prompt": get_request_prompt(request)}
+    for method in ("model_dump", "dict"):
+        fn = getattr(request, method, None)
+        if fn is not None:
+            return fn()
+    return {"prompt": get_request_prompt(request)}
 
 
 def set_request_files(request, files: list) -> None:
@@ -87,8 +61,5 @@ def set_request_files(request, files: list) -> None:
 
 def get_request_use_assistant_model(request) -> bool:
     """Get use_assistant_model from request, defaulting to True."""
-    try:
-        val = request.use_assistant_model
-        return val if val is not None else True
-    except AttributeError:
-        return True
+    val = getattr(request, "use_assistant_model", None)
+    return val if val is not None else True

--- a/tools/testgen.py
+++ b/tools/testgen.py
@@ -20,7 +20,6 @@ from typing import Any, Optional
 
 from pydantic import Field
 
-from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
 from systemprompts import TESTGEN_PROMPT
 from tools.shared.base_models import WorkflowRequest
@@ -113,12 +112,7 @@ class TestGenTool(StatefulTool):
     def get_system_prompt(self) -> str:
         return TESTGEN_PROMPT
 
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_ANALYTICAL
-
-    def get_model_category(self) -> ToolModelCategory:
-        """Test generation requires thorough analysis and reasoning"""
-        return ToolModelCategory.EXTENDED_REASONING
+    MODEL_CATEGORY = ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):
         """Return the test generation workflow-specific request model."""

--- a/tools/thinkdeep.py
+++ b/tools/thinkdeep.py
@@ -18,7 +18,6 @@ from typing import Any, Optional
 
 from pydantic import Field
 
-from config import TEMPERATURE_CREATIVE
 from shared_types import ToolModelCategory
 from systemprompts import THINKDEEP_PROMPT
 from tools.shared.base_models import WorkflowRequest
@@ -121,9 +120,7 @@ class ThinkDeepTool(StatefulTool):
         """Return the tool description"""
         return self.description
 
-    def get_model_category(self) -> ToolModelCategory:
-        """Return the model category for this tool"""
-        return ToolModelCategory.EXTENDED_REASONING
+    MODEL_CATEGORY = ToolModelCategory.EXTENDED_REASONING
 
     def get_workflow_request_model(self):
         """Return the workflow request model for this tool"""
@@ -157,10 +154,6 @@ class ThinkDeepTool(StatefulTool):
     def get_system_prompt(self) -> str:
         """Return the system prompt for this workflow tool"""
         return THINKDEEP_PROMPT
-
-    def get_default_temperature(self) -> float:
-        """Return default temperature for deep thinking"""
-        return TEMPERATURE_CREATIVE
 
     def get_default_thinking_mode(self) -> str:
         """Return default thinking mode for thinkdeep"""

--- a/tools/tracer.py
+++ b/tools/tracer.py
@@ -24,7 +24,6 @@ from typing import Any, Literal, Optional
 
 from pydantic import Field, field_validator
 
-from config import TEMPERATURE_ANALYTICAL
 from shared_types import ToolModelCategory
 from systemprompts import TRACER_PROMPT
 from tools.shared.base_models import WorkflowRequest
@@ -160,12 +159,7 @@ class TracerTool(StatefulTool):
     def get_system_prompt(self) -> str:
         return TRACER_PROMPT
 
-    def get_default_temperature(self) -> float:
-        return TEMPERATURE_ANALYTICAL
-
-    def get_model_category(self) -> ToolModelCategory:
-        """Tracer requires analytical reasoning for code analysis"""
-        return ToolModelCategory.EXTENDED_REASONING
+    MODEL_CATEGORY = ToolModelCategory.EXTENDED_REASONING
 
     def requires_model(self) -> bool:
         """

--- a/tools/version.py
+++ b/tools/version.py
@@ -365,6 +365,4 @@ class VersionTool(BaseTool):
 
         return [TextContent(type="text", text=tool_output.model_dump_json())]
 
-    def get_model_category(self) -> ToolModelCategory:
-        """Return the model category for this tool."""
-        return ToolModelCategory.FAST_RESPONSE  # Simple version info, no AI needed
+    MODEL_CATEGORY = ToolModelCategory.FAST_RESPONSE


### PR DESCRIPTION
## Summary

Resolves #6 — eliminates three categories of copy-pasted boilerplate across 18+ tool files.

- **Temperature constants**: Replaced three identical constants (`TEMPERATURE_ANALYTICAL`, `TEMPERATURE_BALANCED`, `TEMPERATURE_CREATIVE` — all `1.0`) with a single `DEFAULT_TEMPERATURE = 1.0`. Removed all 16 per-tool `get_default_temperature()` overrides and updated the base default from `0.5` to `DEFAULT_TEMPERATURE`.
- **Model category**: Replaced per-tool `get_model_category()` method overrides with a `MODEL_CATEGORY` class attribute on each tool. `BaseTool.get_model_category()` now reads `self.MODEL_CATEGORY`, preserving backward compatibility for all callers.
- **Request accessors**: Simplified 10 accessor functions in `request_helpers.py` by replacing `try/except AttributeError` blocks with `getattr()` calls.
- **Dead code**: Removed unused `self.default_temperature` cache from `BaseTool.__init__`.

**Net result**: 55 insertions, 210 deletions across 30 files (~155 lines removed).

## Test plan

- [x] All 1034 unit tests pass (0 failures, 4 skipped)
- [x] Ruff linting, Black formatting, isort all pass
- [x] Verified no remaining imports of old temperature constants
- [x] Verified `get_model_category()` still works via `self.MODEL_CATEGORY` resolution
- [x] Verified `self.default_temperature` has no remaining consumers

https://claude.ai/code/session_01YPSmPYtcQ9qzAowNDQFsX6